### PR TITLE
Fix an issue where we would trim nodes and end up with an invalid AST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 /npm/glslx
 /node_modules/
-/www/compiled.js
+/www/glslx.js

--- a/src/core/rewriter.sk
+++ b/src/core/rewriter.sk
@@ -164,10 +164,13 @@ class GLSLX.Rewriter {
 
       case .VARIABLES {
         if node.variablesType.nextSibling == null {
-          if node.parent.kind == .FOR && node == node.forSetup {
-            node.replaceWith(Node.createSequence)
+          # If it lives in a block or is global, remove it. Otherwise we can't
+          # blindly remove it, or we risk removing the true-branch of an
+          # if-statement or the body of a for-loop, leading to an invalid AST.
+          if node.parent.kind == NodeKind.BLOCK || node.parent.kind == NodeKind.GLOBAL {
+              node.remove
           } else {
-            node.remove
+              node.become(Node.createBlock)
           }
           _reportCodeChange
         }

--- a/src/test/rewriter.tests.sk
+++ b/src/test/rewriter.tests.sk
@@ -587,6 +587,23 @@ void main() {
 }
 ").renameAll.trimSymbols
 
+# There was previously a crash in this case where we would
+# remove the true-branch of the if-statement leading to an
+# invalid AST.
+test("
+bool func() { /* This function might run important code. */ }
+
+export void test() {
+  if (func())
+    float thing = 1.0; // Unused, so it will be removed
+}", "
+bool func() {
+}
+
+void main() {
+  func();
+}").trimSymbols.compactSyntaxTree
+
 # Test explicit extensions
 test("
 #extension GL_OES_standard_derivatives : enable


### PR DESCRIPTION
I didn't see any guidelines for how to submit patches for glslx, so I'm just sending this PR.

I added a test which fails in the current version of master but passes with this change. Other stuff that fails in master but passes here:

```
export void main() {
    if (gl_FragCoord.x != 1.0)
        float unused = 1.0;
    else {
        // This ends up being the true-branch of the conditional
        gl_FragCoord.y = 1.0;
    }
}
```

```
// This ends up as "void main(){for(int a=0;a<10;a<10)POSTFIX_INCREMENT}"
export void main() {
    for (int i = 0; i < 10; i++) {
        float unused = 1.0;
    }
}
```
