### PR TITLE
Exports uniforms and attributes in CompilerResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-/npm/glslx
+/npm/index.js
 /node_modules/
 /www/glslx.js

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,11 @@ watch-release:
 watch-test:
 	$(WATCH) 'clear && make test'
 
-publish: test release
+package: test release
 	rm -f npm/index.js
 	cp www/glslx.js npm/index.js
+
+publish: package
 	sh -c 'cd npm && npm version patch && npm publish'
 
 node_modules:

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,8 @@ watch-test:
 	$(WATCH) 'clear && make test'
 
 publish: test release
-	rm -f npm/glslx
-	echo '#!/usr/bin/env node' > npm/glslx
-	cat www/glslx.js >> npm/glslx
-	chmod +x npm/glslx
+	rm -f npm/index.js
+	cp www/glslx.js npm/index.js
 	sh -c 'cd npm && npm version patch && npm publish'
 
 node_modules:

--- a/npm/glslx
+++ b/npm/glslx
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('./index').cli()

--- a/npm/package.json
+++ b/npm/package.json
@@ -7,6 +7,6 @@
   "bin": {
     "glslx": "glslx"
   },
-  "main": "glslx",
+  "main": "index.js",
   "author": "Evan Wallace"
 }

--- a/src/core/compiler.sk
+++ b/src/core/compiler.sk
@@ -1,5 +1,6 @@
 namespace GLSLX {
   enum OutputFormat {
+    OBJECT
     JSON
     CPP
     SKEW
@@ -48,14 +49,12 @@ namespace GLSLX {
 
     def output(format OutputFormat) string {
       switch format {
+        case .OBJECT {
+          return toJSON
+        }
+
         case .JSON {
-          return dynamic.JSON.stringify({
-            "shaders": shaders == null ? null : shaders.map<dynamic>(source => ({
-              "name": source.name,
-              "contents": source.contents,
-            })),
-            "renaming": renaming,
-          }, null, 2) + "\n"
+          return dynamic.JSON.stringify(toJSON, null, 2) + "\n"
         }
 
         case .CPP {
@@ -91,6 +90,16 @@ namespace GLSLX {
         }
       }
       return null
+    }
+
+    def toJSON dynamic {
+      return {
+        "shaders": shaders == null ? null : shaders.map<dynamic>(source => ({
+          "name": source.name,
+          "contents": source.contents,
+        })),
+        "renaming": renaming
+      }
     }
 
     def _transformName(name string) string {

--- a/src/core/compiler.sk
+++ b/src/core/compiler.sk
@@ -46,6 +46,8 @@ namespace GLSLX {
   class CompilerResult {
     const shaders List<Source>
     const renaming StringMap<string>
+    const uniforms StringMap<StringMap<string>>
+    const attributes StringMap<StringMap<string>>
 
     def output(format OutputFormat) string {
       switch format {
@@ -97,6 +99,8 @@ namespace GLSLX {
         "shaders": shaders == null ? null : shaders.map<dynamic>(source => ({
           "name": source.name,
           "contents": source.contents,
+          "attributes": source.name in attributes ? attributes[source.name] : StringMap<string>.new,
+          "uniforms": source.name in uniforms ? uniforms[source.name] : StringMap<string>.new,
         })),
         "renaming": renaming
       }
@@ -171,6 +175,9 @@ namespace GLSLX.Compiler {
     # per shader.
     var names List<string> = []
     var globals List<Node> = []
+    const uniforms = StringMap<StringMap<string>>.new
+    const attributes = StringMap<StringMap<string>>.new
+
     for root in _collectAllExportedFunctions(scope) {
       var shaderGlobal = Node.createGlobal
       var shaderScope = Scope.new(.GLOBAL, null)
@@ -191,6 +198,40 @@ namespace GLSLX.Compiler {
       Rewriter.rewrite(shaderGlobal, shaderData, options)
       globals.append(shaderGlobal)
       names.append(root.name)
+
+      for i in 0..shaderGlobal.childCount {
+        const child = shaderGlobal.childAt(i)
+
+        if child.kind != .VARIABLES {
+          continue
+        }
+
+        const node = child.childAt(0)
+        const variableType = node.resolvedType.symbol.name
+
+        if variableType == "<error>" {
+          continue
+        }
+
+        for variableIndex in 1..child.childCount {
+          const symbol = child.childAt(variableIndex).symbol
+
+          if symbol.isAttribute {
+            if !(root.name in attributes) {
+              attributes[root.name] = StringMap<string>.new
+            }
+
+            attributes[root.name][symbol.name] = variableType
+          }
+          else if symbol.isUniform {
+            if !(root.name in uniforms) {
+              uniforms[root.name] = StringMap<string>.new
+            }
+            
+            uniforms[root.name][symbol.name] = variableType
+          }
+        }
+      }
     }
 
     # Rename everything together
@@ -199,7 +240,7 @@ namespace GLSLX.Compiler {
     for i in 0..names.count {
       shaders.append(Source.new(names[i], Emitter.emit(globals[i], options)))
     }
-    return CompilerResult.new(shaders, renaming)
+    return CompilerResult.new(shaders, renaming, uniforms, attributes)
   }
 
   def _collectAllExportedFunctions(scope Scope) List<FunctionSymbol> {

--- a/src/exports/exports.sk
+++ b/src/exports/exports.sk
@@ -9,6 +9,7 @@
 
 namespace GLSLX.Exports {
   const outputFormats StringMap<OutputFormat> = {
+    "object": .OBJECT,
     "json": .JSON,
     "c++": .CPP,
     "skew": .SKEW,

--- a/src/exports/exports.sk
+++ b/src/exports/exports.sk
@@ -473,8 +473,6 @@ Advanced:
     root.compileIDE = compileIDE
 
     # Also include a small command-line utility for when this is run in node
-    if dynamic.typeof(require) != "undefined" && dynamic.typeof(module) != "undefined" && require.main == module {
-      commandLineMain
-    }
+    root.cli = => commandLineMain
   }
 }

--- a/src/test/emitter.tests.sk
+++ b/src/test/emitter.tests.sk
@@ -91,11 +91,19 @@ export void bar() { float local = global; gl_FragColor = vec4(local + internal);
   \"shaders\": [
     {
       \"name\": \"foo\",
-      \"contents\": \"uniform float global;varying float internal;void main(){float local=global;gl_FragColor=vec4(local+internal);}\"
+      \"contents\": \"uniform float global;varying float internal;void main(){float local=global;gl_FragColor=vec4(local+internal);}\",
+      \"attributes\": {},
+      \"uniforms\": {
+        \"global\": \"float\"
+      }
     },
     {
       \"name\": \"bar\",
-      \"contents\": \"uniform float global;varying float internal;void main(){float local=global;gl_FragColor=vec4(local+internal);}\"
+      \"contents\": \"uniform float global;varying float internal;void main(){float local=global;gl_FragColor=vec4(local+internal);}\",
+      \"attributes\": {},
+      \"uniforms\": {
+        \"global\": \"float\"
+      }
     }
   ],
   \"renaming\": {
@@ -116,11 +124,19 @@ export void bar() { float local = global; gl_FragColor = vec4(local + internal);
   \"shaders\": [
     {
       \"name\": \"foo\",
-      \"contents\": \"uniform float a;varying float b;void main(){float c=a;gl_FragColor=vec4(c+b);}\"
+      \"contents\": \"uniform float a;varying float b;void main(){float c=a;gl_FragColor=vec4(c+b);}\",
+      \"attributes\": {},
+      \"uniforms\": {
+        \"global\": \"float\"
+      }
     },
     {
       \"name\": \"bar\",
-      \"contents\": \"uniform float a;varying float b;void main(){float c=a;gl_FragColor=vec4(c+b);}\"
+      \"contents\": \"uniform float a;varying float b;void main(){float c=a;gl_FragColor=vec4(c+b);}\",
+      \"attributes\": {},
+      \"uniforms\": {
+        \"global\": \"float\"
+      }
     }
   ],
   \"renaming\": {


### PR DESCRIPTION
I've just started working on [a project which uses GLSLX](https://github.com/fathyb/glslx-loader) and I needed some changes, so I've bundled them in this PR, feel free to cherry-pick!

- Make the library importable with commonjs
- Add a `package` makefile task to debug when using `npm link` (same as publish without the `npm publish`)
- Add an `object` output format to get raw object when using the API
- Export uniforms/attributes with their name and type in `CompilerResult`
