### PR TITLE
Implement a Rust output format

### DIFF
--- a/src/core/compiler.sk
+++ b/src/core/compiler.sk
@@ -3,6 +3,7 @@ namespace GLSLX {
     JSON
     CPP
     SKEW
+    RUST
   }
 
   enum RenameSymbols {
@@ -81,7 +82,7 @@ namespace GLSLX {
 
         case .SKEW {
           if shaders != null {
-          var code = ""
+            var code = ""
             for shader in shaders {
               code += "const GLSLX_SOURCE_\(_transformName(shader.name)) = \(dynamic.JSON.stringify(shader.contents))\n"
             }
@@ -89,6 +90,22 @@ namespace GLSLX {
               code += "\n"
               for name in renaming.keys {
                 code += "const GLSLX_NAME_\(_transformName(name)) = \(dynamic.JSON.stringify(renaming[name]))\n"
+              }
+            }
+            return code
+          }
+        }
+
+        case .RUST {
+          if shaders != null {
+            var code = ""
+            for shader in shaders {
+              code += "pub static GLSLX_SOURCE_\(_transformName(shader.name)): &str = \(dynamic.JSON.stringify(shader.contents));\n"
+            }
+            if renaming != null {
+              code += "\n"
+              for name in renaming.keys {
+                code += "pub static GLSLX_NAME_\(_transformName(name)): &str = \(dynamic.JSON.stringify(renaming[name]));\n"
               }
             }
             return code

--- a/src/exports/exports.sk
+++ b/src/exports/exports.sk
@@ -12,6 +12,7 @@ namespace GLSLX.Exports {
     "json": .JSON,
     "c++": .CPP,
     "skew": .SKEW,
+    "rust": .RUST,
   }
 
   const renameSymbols StringMap<RenameSymbols> = {
@@ -28,7 +29,7 @@ Usage: glslx [sources] [flags]
     Set the path to the output file. Defaults to standard out.
 
   --format=FORMAT
-    Set the output format, must be json, c++, or skew. Defaults to json.
+    Set the output format, must be json, c++, skew or rust. Defaults to json.
 
 Advanced:
 

--- a/src/test/emitter.tests.sk
+++ b/src/test/emitter.tests.sk
@@ -167,7 +167,7 @@ static const char *GLSLX_NAME_GLOBAL = \"a\";
 #endif
 ").removeWhitespace.trimSymbols.renameAll.generateOutput(.CPP)
 
-# Test C++ code generation
+# Test Skew code generation
 test("
 uniform float global;
 varying float internal;
@@ -181,7 +181,7 @@ const GLSLX_SOURCE_BAR = \"uniform float global;varying float internal;void main
 const GLSLX_NAME_GLOBAL = \"global\"
 ").removeWhitespace.trimSymbols.generateOutput(.SKEW)
 
-# Test C++ code generation with renaming
+# Test Skew code generation with renaming
 test("
 uniform float global;
 varying float internal;
@@ -195,5 +195,33 @@ const GLSLX_SOURCE_BAR = \"uniform float a;varying float b;void main(){float c=a
 const GLSLX_NAME_GLOBAL = \"a\"
 ").removeWhitespace.trimSymbols.renameAll.generateOutput(.SKEW)
 
+# Test Rust code generation
+test("
+uniform float global;
+varying float internal;
+
+export void foo() { float local = global; gl_FragColor = vec4(local + internal); }
+export void bar() { float local = global; gl_FragColor = vec4(local + internal); }
+", "
+pub static GLSLX_SOURCE_FOO: &str = \"uniform float global;varying float internal;void main(){float local=global;gl_FragColor=vec4(local+internal);}\";
+pub static GLSLX_SOURCE_BAR: &str = \"uniform float global;varying float internal;void main(){float local=global;gl_FragColor=vec4(local+internal);}\";
+
+pub static GLSLX_NAME_GLOBAL: &str = \"global\";
+").removeWhitespace.trimSymbols.generateOutput(.RUST)
+
+# Test Rust code generation with renaming
+test("
+uniform float global;
+varying float internal;
+
+export void foo() { float local = global; gl_FragColor = vec4(local + internal); }
+export void bar() { float local = global; gl_FragColor = vec4(local + internal); }
+", "
+pub static GLSLX_SOURCE_FOO: &str = \"uniform float a;varying float b;void main(){float c=a;gl_FragColor=vec4(c+b);}\";
+pub static GLSLX_SOURCE_BAR: &str = \"uniform float a;varying float b;void main(){float c=a;gl_FragColor=vec4(c+b);}\";
+
+pub static GLSLX_NAME_GLOBAL: &str = \"a\";
+
+").removeWhitespace.trimSymbols.renameAll.generateOutput(.RUST)
   }
 }

--- a/www/index.html
+++ b/www/index.html
@@ -133,6 +133,7 @@ export void textureFragment() {
         <label><input id="formatJSON" type="radio" name="format" checked> JSON</label> &nbsp;
         <label><input id="formatCPP" type="radio" name="format"> C++</label> &nbsp;
         <label><input id="formatSkew" type="radio" name="format"> Skew</label> &nbsp;
+        <label><input id="formatRust" type="radio" name="format"> Rust</label> &nbsp;
       </p>
     </div>
   </div>
@@ -238,6 +239,7 @@ import {
   format('formatJSON', 'json');
   format('formatCPP', 'c++');
   format('formatSkew', 'skew');
+  format('formatRust', 'rust');
 
   function example(id, content) {
     document.getElementById(id).onclick = function() {


### PR DESCRIPTION
This PR implements a rust output format for GLSLX.

How to use it, assuming you have your shaders defined in some file called `shaders.glslx`...

1. You run `glslx --format=rust shaders.glslx shaders.rs`
2. You add `mod shaders;` to some rust file in your project to declare it as a module
3. You import `path::to::shaders::*` in some rust and use your `GLSLX_` variables like you would in Skew or C++

## Test plan

I added some tests. I also built and opened the web demo locally and selected the Rust option to see it translate the following glsl...

```
uniform sampler2D texture;
uniform vec4 color;
attribute vec2 position;
varying vec2 coord;

export void vertex() {
  coord = position;
  gl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);
}

export void colorFragment() {
  gl_FragColor = color;
}

export void textureFragment() {
  gl_FragColor = texture2D(texture, coord);
}
```

... into...

```
pub static GLSLX_SOURCE_VERTEX: &str = "attribute vec2 b;varying vec2 a;void main(){a=b,gl_Position=vec4(b*2.-1.,0.,1.);}";
pub static GLSLX_SOURCE_COLOR_FRAGMENT: &str = "uniform vec4 c;void main(){gl_FragColor=c;}";
pub static GLSLX_SOURCE_TEXTURE_FRAGMENT: &str = "uniform sampler2D d;varying vec2 a;void main(){gl_FragColor=texture2D(d,a);}";

pub static GLSLX_NAME_POSITION: &str = "b";
pub static GLSLX_NAME_COLOR: &str = "c";
pub static GLSLX_NAME_TEXTURE: &str = "d";
```
