### PR TITLE
Make it possible to include the same file more than once

### DIFF
--- a/src/core/parser.sk
+++ b/src/core/parser.sk
@@ -701,9 +701,15 @@ namespace GLSLX.Parser {
       return false
     }
 
+    if source.name in context.processedIncludes {
+      # We've already processed this include; no need to do it again
+      return true
+    }
+    context.processedIncludes[source.name] = true
+
     # Parse the file and insert it into the parent
     var tokens = Tokenizer.tokenize(context.log, source)
-    var nestedContext = ParserContext.new(context.log, tokens, context.compilationData, context.resolver)
+    var nestedContext = ParserContext.new(context.log, tokens, context.compilationData, context.resolver, context.processedIncludes)
     nestedContext.pushScope(context.scope)
     if !parseStatements(nestedContext, parent, .GLOBAL) || !nestedContext.expect(.END_OF_FILE) {
       return false
@@ -1056,7 +1062,8 @@ namespace GLSLX.Parser {
       pratt = createExpressionParser
     }
 
-    var context = ParserContext.new(log, tokens, data, resolver)
+    const processedIncludes = StringMap<bool>.new
+    var context = ParserContext.new(log, tokens, data, resolver, processedIncludes)
     context.pushScope(scope)
     if parseStatements(context, global, .GLOBAL) {
       context.expect(.END_OF_FILE)

--- a/src/core/pratt.sk
+++ b/src/core/pratt.sk
@@ -25,6 +25,7 @@ namespace GLSLX {
     const _tokens List<Token>
     const compilationData CompilerData
     const resolver Resolver
+    const processedIncludes StringMap<bool>
     var flags SymbolFlags = 0
     var _index = 0
     var _scope Scope = null

--- a/src/test/parser.tests.sk
+++ b/src/test/parser.tests.sk
@@ -856,6 +856,30 @@ varying vec4 _color;
 ")
 })
 
+# Don't include the same file multiple times
+test("
+#include \"C:\\\\foo.glslx\"
+#include \"C:\\\\foo.glslx\"
+
+void main() {
+  _color = color;
+}
+", "
+attribute vec4 color;
+varying vec4 _color;
+
+void main() {
+  _color = color;
+}
+").fileAccess((path, relativeTo) => {
+  assert(path == "C:\\foo.glslx")
+  assert(relativeTo == "<stdin>")
+  return Source.new(path, "
+attribute vec4 color;
+varying vec4 _color;
+")
+})
+
 # Don't allow syntax that spans files
 test("
 #include \"C:\\\\foo.glslx\"


### PR DESCRIPTION
I have files with a dependency chain like this...

 - main.sk includes helpers1.glslx and helpers2.glslx
 - helpers1.glslx and helpers2.glslx both include random.glslx

This is a problem because `main` indirectly includes two copies of `random.glslx` which causes syntax errors. I remember you calling this out when you implemented include statements, but now I want to fix it :)

The way `include` statements currently work is that the parser replaces them with the content of the file that they reference. This PR "fixes" this by having it do this only for the first include it encounters for a particular file.
