### PR TITLE
Add compiler option for ignoring specific symbols

### DIFF
--- a/src/core/compiler.sk
+++ b/src/core/compiler.sk
@@ -18,6 +18,7 @@ namespace GLSLX {
     var removeWhitespace = true
     var renameSymbols = RenameSymbols.ALL
     var trimSymbols = true
+    var ignoredSymbols List<string> = []
     var fileAccess fn(string, string) Source = null
   }
 

--- a/src/core/renamer.sk
+++ b/src/core/renamer.sk
@@ -1,6 +1,6 @@
 namespace GLSLX.Renamer {
   def rename(globals List<Node>, options CompilerOptions) StringMap<string> {
-    return Renamer.new(options.renameSymbols)._rename(globals)
+    return Renamer.new(options.renameSymbols, options.ignoredSymbols)._rename(globals)
   }
 
   class SymbolInfo {
@@ -28,6 +28,7 @@ namespace GLSLX.Renamer {
 
 class GLSLX.Renamer {
   var _renameSymbols RenameSymbols
+  var _ignoredSymbols List<string>
   var _functionList List<SymbolInfo> = []
   var _symbolInfoList List<SymbolInfo> = []
   var _symbolInfoMap IntMap<SymbolInfo> = {}
@@ -55,6 +56,9 @@ class GLSLX.Renamer {
       var name string = null
       for info in group {
         for symbol in info.symbols.values {
+          if symbol.name in _ignoredSymbols {
+            continue
+          }
           var old = symbol.name
           if !symbol.isImportedOrExported && (_renameSymbols == .ALL || _renameSymbols == .INTERNAL_ONLY && !symbol.isAttributeOrUniform) {
             if name == null {
@@ -136,7 +140,7 @@ class GLSLX.Renamer {
     while true {
       var name = _numberToName(_nextSymbolName)
       _nextSymbolName++
-      if name in Tokenizer.keywords || name in Tokenizer.reservedWords || name.startsWith("gl_") {
+      if name in Tokenizer.keywords || name in Tokenizer.reservedWords || name.startsWith("gl_") || name in _ignoredSymbols {
         continue
       }
       return name

--- a/src/exports/exports.sk
+++ b/src/exports/exports.sk
@@ -43,6 +43,9 @@ Advanced:
   --renaming=MODE
     Valid modes are all, internal-only, or none. Defaults to all.
 
+  --ignored-symbols=SYMBOLS
+    A list of symbols to be ignored during renaming. Formatted as a JSON array. Defaults to an empty array.
+
   --keep-symbols
     Don't inline constants or remove unused symbols.
 ")
@@ -166,6 +169,7 @@ Advanced:
     if args.disableRewriting { options.compactSyntaxTree = false }
     if args.prettyPrint { options.removeWhitespace = false }
     if args.keepSymbols { options.trimSymbols = false }
+    if args.ignoredSymbols { options.ignoredSymbols = args.ignoredSymbols }
     if args.fileAccess { options.fileAccess = wrapFileAccess(args.fileAccess) }
 
     var result = Compiler.compile(log, sources, options)
@@ -513,6 +517,10 @@ Advanced:
               process.exit(1)
             }
             options.renameSymbols = renameSymbols[text]
+          }
+
+          else if arg.startsWith("--ignored-symbols=") {
+            options.ignoredSymbols = dynamic.JSON.parse(arg.slice("--ignored-symbols=".count))
           }
 
           else {

--- a/src/test/driver.sk
+++ b/src/test/driver.sk
@@ -34,6 +34,7 @@ namespace GLSLX.Tests {
       _options.removeWhitespace = false
       _options.renameSymbols = .NONE
       _options.trimSymbols = false
+      _options.ignoredSymbols = []
       return self
     }
 
@@ -54,6 +55,11 @@ namespace GLSLX.Tests {
 
     def trimSymbols CompilerTest {
       _options.trimSymbols = true
+      return self
+    }
+
+    def ignoredSymbols(ignoredSymbols List<string>) CompilerTest {
+      _options.ignoredSymbols = ignoredSymbols
       return self
     }
 
@@ -172,6 +178,7 @@ namespace GLSLX.Tests {
     testMinifier
     testParser
     testResolver
+    testRenamer
     testRewriter
     testTooltips
     testFormatter

--- a/src/test/renamer.tests.sk
+++ b/src/test/renamer.tests.sk
@@ -1,0 +1,80 @@
+namespace GLSLX.Tests {
+  def testRenamer {
+test("
+uniform sampler2D texture;
+uniform vec4 color;
+attribute vec2 position;
+varying vec2 coord;
+
+export void vertex() {
+  coord = position;
+  gl_Position = vec4(position*2.0 - 1.0, 0.0,1.0);
+}
+
+export void colorFragment() {
+  gl_FragColor = color;
+}
+
+export void textureFragment() {
+  gl_FragColor = texture2D(texture, coord);
+}
+", "
+[vertex]
+uniform sampler2D f;
+uniform vec4 g;
+attribute vec2 position;
+varying vec2 e;
+
+void main() {
+  e = position;
+  gl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);
+}
+
+void h() {
+  gl_FragColor = g;
+}
+
+void i() {
+  gl_FragColor = texture2D(f, e);
+}
+
+[colorFragment]
+uniform sampler2D f;
+uniform vec4 g;
+attribute vec2 position;
+varying vec2 e;
+
+void vertex() {
+  e = position;
+  gl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);
+}
+
+void main() {
+  gl_FragColor = g;
+}
+
+void i() {
+  gl_FragColor = texture2D(f, e);
+}
+
+[textureFragment]
+uniform sampler2D f;
+uniform vec4 g;
+attribute vec2 position;
+varying vec2 e;
+
+void vertex() {
+  e = position;
+  gl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);
+}
+
+void h() {
+  gl_FragColor = g;
+}
+
+void main() {
+  gl_FragColor = texture2D(f, e);
+}
+").ignoredSymbols(["position", "vertex"]).renameAll
+  }
+}


### PR DESCRIPTION
It is essential to have the ability to preserve certain symbols from renaming when pairing GLSLX with external frameworks in which specific symbols are static. 

This is addressed by adding an additional variable `ignoredSymbols List<string>` to `CompilerOptions` which is checked against when renaming symbols & generating new symbol names.

Ignored symbols can be passed via the command line using the `--ignored-symbols` argument which accepts a JSON formatted array for example; `--ignored-symbols='["foo", "bar"]'`